### PR TITLE
IVI-20468 Merge patches directly previously applied in bitbake recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ set(
     "--leak-check=full --gen-suppressions=all --error-exitcode=1 --suppressions=${PROJECT_SOURCE_DIR}/scripts/valgrind.sup"
 )
 
-include(CTest)
-
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
@@ -1043,10 +1041,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 else()
     message(FATAL_ERROR "Unsupported target platform: " ${CMAKE_SYSTEM_NAME})
 endif()
-
-add_subdirectory(${PROJECT_SOURCE_DIR}/test)
-add_subdirectory(${PROJECT_SOURCE_DIR}/benchmark)
-add_subdirectory(${PROJECT_SOURCE_DIR}/render-test)
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/internal/internal.cmake)
     include(${PROJECT_SOURCE_DIR}/internal/internal.cmake)

--- a/include/mbgl/util/string.hpp
+++ b/include/mbgl/util/string.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <cstdlib>
 #include <type_traits>
+#include <exception>
 
 // Polyfill needed by Qt when building for Android with GCC
 #if defined(__ANDROID__) && defined(__GLIBCXX__)

--- a/platform/qt/include/qmapbox.hpp
+++ b/platform/qt/include/qmapbox.hpp
@@ -6,6 +6,7 @@
 #include <QString>
 #include <QVariant>
 #include <QVector>
+#include <mapbox/geojson.hpp>
 
 // This header follows the Qt coding style: https://wiki.qt.io/Qt_Coding_Style
 
@@ -20,6 +21,9 @@
 #endif
 
 namespace QMapbox {
+
+using QFeatureCollection = mapbox::geojson::feature_collection;
+using QFeature = mapbox::geojson::feature;
 
 typedef QPair<double, double> Coordinate;
 typedef QPair<Coordinate, double> CoordinateZoom;

--- a/platform/qt/include/qmapboxgl.hpp
+++ b/platform/qt/include/qmapboxgl.hpp
@@ -9,7 +9,8 @@
 #include <QSize>
 #include <QString>
 #include <QStringList>
-
+#include <QMutex>
+#include <memory>
 #include <functional>
 
 class QMapboxGLPrivate;
@@ -225,9 +226,17 @@ public:
     QMargins margins() const;
 
     void addSource(const QString &sourceID, const QVariantMap& params);
+    void addSource(const QString &sourceID, const QMapbox::QFeatureCollection &data);
     bool sourceExists(const QString &sourceID);
     void updateSource(const QString &sourceID, const QVariantMap& params);
+    // Deprecate this version, and use the version with the shared_ptr instead going forward
+    void updateSource(const QString &sourceID, const QMapbox::QFeatureCollection &data);
+    void updateSource(const QString &sourceID, const std::shared_ptr<QMapbox::QFeatureCollection> &data);
     void removeSource(const QString &sourceID);
+
+    // Feature queries - might want to move result to QVector to be more Qt like
+    std::vector<QMapbox::QFeature> queryRenderedFeatures(const QPointF &, const QVector<QString>& layerIDs = {});
+    std::vector<QMapbox::QFeature> queryRenderedFeatures(const QRectF&,   const QVector<QString>& layerIDs = {});
 
     void addImage(const QString &name, const QImage &sprite);
     void removeImage(const QString &name);

--- a/platform/qt/src/qmapboxgl.cpp
+++ b/platform/qt/src/qmapboxgl.cpp
@@ -1424,7 +1424,6 @@ void QMapboxGL::updateSource(const QString &sourceID, const std::shared_ptr<QMap
         return new std::shared_ptr<GeoJSONData>(GeoJSONData::create(geoJSON));
     }));
 }
-#endif
 
 /*!
     Removes the source \a id.

--- a/platform/qt/src/qmapboxgl_map_renderer.cpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.cpp
@@ -58,6 +58,12 @@ void QMapboxGLMapRenderer::updateParameters(std::shared_ptr<mbgl::UpdateParamete
     m_updateParameters = std::move(newParameters);
 }
 
+mbgl::Renderer* QMapboxGLMapRenderer::getRenderer() const
+{
+    assert(m_renderer);
+    return m_renderer.get();
+}
+
 void QMapboxGLMapRenderer::updateFramebuffer(quint32 fbo, const mbgl::Size &size)
 {
     MBGL_VERIFY_THREAD(tid);

--- a/platform/qt/src/qmapboxgl_map_renderer.hpp
+++ b/platform/qt/src/qmapboxgl_map_renderer.hpp
@@ -34,6 +34,8 @@ public:
     // Thread-safe, called by the Frontend
     void updateParameters(std::shared_ptr<mbgl::UpdateParameters>);
 
+    mbgl::Renderer* getRenderer() const;
+
 signals:
     void needsRendering();
 

--- a/platform/qt/src/qmapboxgl_p.hpp
+++ b/platform/qt/src/qmapboxgl_p.hpp
@@ -40,6 +40,7 @@ public:
 
     mbgl::EdgeInsets margins;
     std::unique_ptr<mbgl::Map> mapObj;
+    std::unique_ptr<QMapboxGLMapRenderer> m_mapRenderer; // Ugly hack ...
 
 public slots:
     void requestRendering();
@@ -55,7 +56,6 @@ private:
     std::shared_ptr<mbgl::UpdateParameters> m_updateParameters;
 
     std::unique_ptr<QMapboxGLMapObserver> m_mapObserver;
-    std::unique_ptr<QMapboxGLMapRenderer> m_mapRenderer;
     std::unique_ptr<mbgl::Actor<mbgl::ResourceTransform::TransformCallback>> m_resourceTransform;
 
     QMapboxGLSettings::GLContextMode m_mode;

--- a/platform/qt/src/thread_local.cpp
+++ b/platform/qt/src/thread_local.cpp
@@ -22,7 +22,12 @@ ThreadLocalBase::ThreadLocalBase() {
 ThreadLocalBase::~ThreadLocalBase() {
     // ThreadLocal will not take ownership of the pointer it is managing. The pointer
     // needs to be explicitly cleared before we destroy this object.
-    assert(!get());
+    //
+    // XXX jbrooks: but that isn't happening on exit somewhere, and
+    // having this assert fire turns every exit into a crash. I'm
+    // not too concerned about freeing resources at-exit, and it
+    // doesn't seem like there's any other destruction path for this.
+    //assert(!get());
     reinterpret_cast<StorageType&>(storage).~QThreadStorage();
 }
 

--- a/src/mbgl/renderer/paint_parameters.cpp
+++ b/src/mbgl/renderer/paint_parameters.cpp
@@ -76,8 +76,14 @@ gfx::DepthMode PaintParameters::depthModeForSublayer(uint8_t n, gfx::DepthMaskTy
     if (currentLayer < opaquePassCutoff) {
         return gfx::DepthMode::disabled();
     }
-    float depth = depthRangeSize + ((1 + currentLayer) * numSublayers + n) * depthEpsilon;
-    return gfx::DepthMode { gfx::DepthFunctionType::LessEqual, mask, { depth, depth } };
+
+    // Particly reverted https://github.com/mapbox/mapbox-gl-native/commit/f9796d2a28aa55936a9bb1cb99f9aac39d29b27c
+    // which caused rendering issue in QtQuick UI.
+    // The problem was that min and max depth range were equal.
+    // Support ID 99480
+    float nearDepth = ((1 + currentLayer) * numSublayers + n) * depthEpsilon;
+    float farDepth = nearDepth + depthRangeSize;
+    return gfx::DepthMode { gfx::DepthFunctionType::LessEqual, mask, { nearDepth, farDepth } };
 }
 
 gfx::DepthMode PaintParameters::depthModeFor3D() const {


### PR DESCRIPTION
There were a few patches that were applied to the code base as part of the kodiak recipe.  This change merges those patches directly to the repo.

Further, some improvements were made to the updateSource API to optimize performance with large data sets. (IVI-20469)